### PR TITLE
Reformat timers

### DIFF
--- a/src/ExawindSolver.h
+++ b/src/ExawindSolver.h
@@ -74,14 +74,15 @@ public:
         update_solution();
         m_timers.tock(name);
     };
-    void echo_timers()
+    void echo_timers(const int step)
     {
         int rank, minrank;
         MPI_Allreduce(&rank, &minrank, 1, MPI_INT, MPI_MIN, comm());
         ParallelPrinter printer(comm(), minrank);
         const auto timings = m_timers.get_timings(comm(), printer.io_rank());
-        printer.echo(identifier() + " WCTime:");
-        printer.echo(timings);
+        printer.echo(
+            identifier() + " WCTime at step: " + std::to_string(step) + " " +
+            timings);
     }
     virtual bool is_unstructured() { return false; };
     virtual bool is_amr() { return false; };

--- a/src/ExawindSolver.h
+++ b/src/ExawindSolver.h
@@ -74,15 +74,13 @@ public:
         update_solution();
         m_timers.tock(name);
     };
-    void echo_timers(const int step)
+    void echo_timers()
     {
         int rank, minrank;
         MPI_Allreduce(&rank, &minrank, 1, MPI_INT, MPI_MIN, comm());
         ParallelPrinter printer(comm(), minrank);
         const auto timings = m_timers.get_timings(comm(), printer.io_rank());
-        printer.echo(
-            identifier() + " WCTime at step: " + std::to_string(step) + " " +
-            timings);
+        printer.echo(identifier() + " WCTime at step: " + " " + timings);
     }
     virtual bool is_unstructured() { return false; };
     virtual bool is_amr() { return false; };

--- a/src/ExawindSolver.h
+++ b/src/ExawindSolver.h
@@ -74,13 +74,15 @@ public:
         update_solution();
         m_timers.tock(name);
     };
-    void echo_timers()
+    void echo_timers(const int step)
     {
         int rank, minrank;
         MPI_Allreduce(&rank, &minrank, 1, MPI_INT, MPI_MIN, comm());
         ParallelPrinter printer(comm(), minrank);
         const auto timings = m_timers.get_timings(comm(), printer.io_rank());
-        printer.echo(identifier() + " WCTime at step: " + " " + timings);
+        const std::string out =
+            identifier() + " WCTime at step: " + std::to_string(step);
+        printer.echo(out + " " + timings);
     }
     virtual bool is_unstructured() { return false; };
     virtual bool is_amr() { return false; };

--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -132,7 +132,7 @@ void OversetSimulation::run_timesteps(int nsteps)
         m_printer.echo(
             "OversetSimulation WCTime at step: " + std::to_string(nt) + " " +
             timings);
-        for (auto& ss : m_solvers) ss->echo_timers();
+        for (auto& ss : m_solvers) ss->echo_timers(nt);
     }
 
     m_last_timestep = tend;

--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -129,10 +129,10 @@ void OversetSimulation::run_timesteps(int nsteps)
 
         MPI_Barrier(m_comm);
         const auto timings = m_timers.get_timings(m_comm, m_printer.io_rank());
-        m_printer.echo("Wallclock times at step "+ std::to_string(nt));
-        m_printer.echo("OversetSimulation WCTime:");
-        m_printer.echo(timings);
-        for (auto& ss : m_solvers) ss->echo_timers();
+        m_printer.echo(
+            "OversetSimulation WCTime at step: " + std::to_string(nt) + " " +
+            timings);
+        for (auto& ss : m_solvers) ss->echo_timers(nt);
     }
 
     m_last_timestep = tend;

--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -132,7 +132,7 @@ void OversetSimulation::run_timesteps(int nsteps)
         m_printer.echo(
             "OversetSimulation WCTime at step: " + std::to_string(nt) + " " +
             timings);
-        for (auto& ss : m_solvers) ss->echo_timers(nt);
+        for (auto& ss : m_solvers) ss->echo_timers();
     }
 
     m_last_timestep = tend;

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -110,15 +110,14 @@ struct Timers
         const double ms2s = 1000.0;
         for (int i = 0; i < len; i++) {
             out.append(
-                "  " + m_names.at(i) + ": " +
-                std::to_string(avgtimes.at(i) / ms2s) +
-                " (min: " + std::to_string(mintimes.at(i) / ms2s) +
-                ", max: " + std::to_string(maxtimes.at(i) / ms2s) + ")\n");
+                m_names.at(i) + ": " + std::to_string(mintimes.at(i) / ms2s) +
+                " " + std::to_string(avgtimes.at(i) / ms2s) + " " +
+                std::to_string(maxtimes.at(i) / ms2s));
         }
         const double total = std::accumulate(
             avgtimes.begin(), avgtimes.end(),
             decltype(avgtimes)::value_type(0.0));
-        out.append("  Total: " + std::to_string(total / ms2s) + "\n");
+        out.append("  Total: " + std::to_string(total / ms2s));
         return out;
     };
 };

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -112,12 +112,12 @@ struct Timers
             out.append(
                 m_names.at(i) + ": " + std::to_string(mintimes.at(i) / ms2s) +
                 " " + std::to_string(avgtimes.at(i) / ms2s) + " " +
-                std::to_string(maxtimes.at(i) / ms2s));
+                std::to_string(maxtimes.at(i) / ms2s) + " ");
         }
         const double total = std::accumulate(
             avgtimes.begin(), avgtimes.end(),
             decltype(avgtimes)::value_type(0.0));
-        out.append("  Total: " + std::to_string(total / ms2s));
+        out.append("Total: " + std::to_string(total / ms2s));
         return out;
     };
 };


### PR DESCRIPTION
Reformatting the timer output for easier parsing. It now looks like:
```
OversetSimulation WCTime at step: 2 TGConn: 0.007000 0.602500 1.199000 Total: 0.602500
AMR-Wind WCTime at step: 2 Pre: 0.005000 0.005000 0.005000 Conn: 0.114000 0.115000 0.116000 Solve: 4.798000 4.798000 4.798000 Post: 0.007000 0.007000 0.007000 Total: 4.925000
Nalu-Wind WCTime at step: 2 Pre: 1.380000 1.380000 1.380000 Conn: 0.003000 0.003000 0.003000 Solve: 3.191000 3.191000 3.191000 Post: 0.009000 0.009000 0.009000 Total: 4.583000
```