### PR TITLE
Correcting the output time step in restart simulations

### DIFF
--- a/src/AMRWind.cpp
+++ b/src/AMRWind.cpp
@@ -97,4 +97,7 @@ int AMRWind::overset_update_interval()
     const int regrid_int = m_incflo.sim().time().regrid_interval();
     return regrid_int > 0 ? regrid_int : 100000000;
 }
+
+int AMRWind::time_index() { return m_incflo.sim().time().time_index(); }
+
 } // namespace exawind

--- a/src/AMRWind.h
+++ b/src/AMRWind.h
@@ -27,6 +27,7 @@ public:
     bool is_unstructured() override { return false; }
     bool is_amr() override { return true; }
     int overset_update_interval() override;
+    int time_index() override;
     std::string identifier() override { return "AMR-Wind"; }
     MPI_Comm comm() override { return m_comm; }
 

--- a/src/ExawindSolver.h
+++ b/src/ExawindSolver.h
@@ -77,6 +77,7 @@ public:
     void echo_timers(const int step)
     {
         int rank, minrank;
+        MPI_Comm_rank(comm(), &rank);
         MPI_Allreduce(&rank, &minrank, 1, MPI_INT, MPI_MIN, comm());
         ParallelPrinter printer(comm(), minrank);
         const auto timings = m_timers.get_timings(comm(), printer.io_rank());
@@ -87,6 +88,7 @@ public:
     virtual bool is_unstructured() { return false; };
     virtual bool is_amr() { return false; };
     virtual int overset_update_interval() { return 100000000; };
+    virtual int time_index() = 0;
     virtual std::string identifier() { return "ExawindSolver"; }
     virtual MPI_Comm comm() = 0;
     //! Timer names

--- a/src/NaluWind.cpp
+++ b/src/NaluWind.cpp
@@ -115,4 +115,6 @@ int NaluWind::overset_update_interval()
     return 100000000;
 }
 
+int NaluWind::time_index() { return m_sim.timeIntegrator_->timeStepCount_; }
+
 } // namespace exawind

--- a/src/NaluWind.h
+++ b/src/NaluWind.h
@@ -33,6 +33,7 @@ public:
     bool is_unstructured() override { return true; }
     bool is_amr() override { return false; }
     int overset_update_interval() override;
+    int time_index() override;
     std::string identifier() override { return "Nalu-Wind"; }
     MPI_Comm comm() override { return m_comm; }
 

--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -67,6 +67,13 @@ void OversetSimulation::initialize()
 
     for (auto& ss : m_solvers) ss->call_prepare_solver_epilog();
 
+    if (!(std::all_of(m_solvers.begin() + 1, m_solvers.end(), [&](auto& ss) {
+            return ss->time_index() == m_solvers.at(0)->time_index();
+        }))) {
+        throw std::runtime_error("Mismatch in solver time steps.");
+    }
+    m_last_timestep = m_solvers.at(0)->time_index();
+
     MPI_Barrier(m_comm);
     m_initialized = true;
 }


### PR DESCRIPTION
For restart simulations, this PR makes it so we get this:
```
Running 200000 timesteps starting from 26001
OversetSimulation WCTime at step: 26001 TGConn: 0.001000 0.009907 0.025000 Total: 0.009907
AMR-Wind WCTime at step: 26001 Pre: 0.001000 0.001958 0.002000 PreConn: 0.000000 0.000917 0.001000 PostConn: 0.050000 0.050993 0.051000 Register: 0.017000 0.018118 0.019000 Update: 0.015000 0.020201 0.022000 Solve: 1.488000 1.488854 1.489000 Post: 0.002000 0.002000 0.002000 Total: 1.583042
Nalu-Wind WCTime at step: 26001 Pre: 0.000000 0.000000 0.000000 PreConn: 0.001000 0.001000 0.001000 PostConn: 0.001000 0.001000 0.001000 Register: 0.000000 0.000000 0.000000 Update: 0.000000 0.000000 0.000000 Solve: 1.667000 1.667958 1.670000 Post: 0.009000 0.009000 0.009000 Total: 1.678958
```
Instead of the more confusing:
```
Running 200000 timesteps starting from 1
OversetSimulation WCTime at step: 1 TGConn: 0.001000 0.009907 0.025000 Total: 0.009907
AMR-Wind WCTime at step: 1 Pre: 0.001000 0.001958 0.002000 PreConn: 0.000000 0.000917 0.001000 PostConn: 0.050000 0.050993 0.051000 Register: 0.017000 0.018118 0.019000 Update: 0.015000 0.020201 0.022000 Solve: 1.488000 1.488854 1.489000 Post: 0.002000 0.002000 0.002000 Total: 1.583042
Nalu-Wind WCTime at step: 1 Pre: 0.000000 0.000000 0.000000 PreConn: 0.001000 0.001000 0.001000 PostConn: 0.001000 0.001000 0.001000 Register: 0.000000 0.000000 0.000000 Update: 0.000000 0.000000 0.000000 Solve: 1.667000 1.667958 1.670000 Post: 0.009000 0.009000 0.009000 Total: 1.678958
```