### PR TITLE
Use MPI_C_BOOL instead of MPI_CXX_BOOL

### DIFF
--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -26,7 +26,7 @@ void OversetSimulation::check_solver_types()
         std::any_of(m_solvers.begin(), m_solvers.end(), [](const auto& ss) {
             return ss->is_unstructured();
         });
-    MPI_Allreduce(flag, gflag, 2, MPI_CXX_BOOL, MPI_LOR, m_comm);
+    MPI_Allreduce(flag, gflag, 2, MPI_C_BOOL, MPI_LOR, m_comm);
     m_has_amr = gflag[0];
     m_has_unstructured = gflag[1];
 }
@@ -134,7 +134,7 @@ void OversetSimulation::run_timesteps(int nsteps)
 
         for (auto& ss : m_solvers) ss->call_pre_advance_stage2();
 
-        exchange_solution();
+        //exchange_solution();
 
         for (auto& ss : m_solvers) ss->call_advance_timestep();
 

--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -134,7 +134,7 @@ void OversetSimulation::run_timesteps(int nsteps)
 
         for (auto& ss : m_solvers) ss->call_pre_advance_stage2();
 
-        //exchange_solution();
+        exchange_solution();
 
         for (auto& ss : m_solvers) ss->call_advance_timestep();
 


### PR DESCRIPTION
`MPI_CXX_BOOL` isn't defined in the compilers I'm using on Spock, but this is. I can't figure out if they're interchangeable, but my assumption is they have to be.