### PR TITLE
Allow for restarts at non-original mesh positions

### DIFF
--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -58,13 +58,13 @@ void OversetSimulation::initialize()
 
     determine_overset_interval();
 
-    perform_overset_connectivity();
 
     for (auto& ss : m_solvers) {
         ss->call_init_epilog();
         ss->call_prepare_solver_prolog();
     }
 
+    perform_overset_connectivity();
     exchange_solution();
 
     for (auto& ss : m_solvers) ss->call_prepare_solver_epilog();


### PR DESCRIPTION
Currently we perform overset connectivity before nalu-wind has had a chance to populate a restart.  Moving the connectivity calculations after the solvers prepare themselves should account for this scenario.  Still needs to be tested.