### PR TITLE
Remove -fallow-argument-mismatch from fortran MPI compiler flags if found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,3 +22,10 @@ target_link_libraries(${EXAWIND_LIB_NAME} PUBLIC
   AMR-Wind::buildInfoamrwind_obj
   AMReX::amrex
   Nalu-Wind::nalu)
+
+# Solve -fallow-argument-mismatch from fortran possibly making its way into arguments passed to clang
+if(CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|AppleClang)$")
+  get_target_property(TARGET_FLAGS MPI::MPI_Fortran INTERFACE_COMPILE_OPTIONS)
+  string(REPLACE "-fallow-argument-mismatch" "" TARGET_FLAGS ${TARGET_FLAGS})
+  set_target_properties(MPI::MPI_Fortran PROPERTIES INTERFACE_COMPILE_OPTIONS "${TARGET_FLAGS}")
+endif()


### PR DESCRIPTION
This is so that it doesn't cause errors with clang.