### PR TITLE
Add timer for total time step and reformat timer output

### DIFF
--- a/src/ExawindSolver.cpp
+++ b/src/ExawindSolver.cpp
@@ -18,7 +18,7 @@ long ExawindSolver::mem_usage()
     int psize;
     MPI_Comm_size(comm(), &psize);
     const std::string out =
-        identifier() + " Memory Usage" + " min: " + std::to_string(minmem) +
+        identifier() + " memory --" + " min: " + std::to_string(minmem) +
         " avg: " + std::to_string((long)((double)totmem / (double)psize)) +
         " max: " + std::to_string(maxmem) + " total: " + std::to_string(totmem);
     printer.echo(out);

--- a/src/ExawindSolver.h
+++ b/src/ExawindSolver.h
@@ -89,9 +89,8 @@ public:
     {
         ParallelPrinter printer(comm());
         const auto timings = m_timers.get_timings(comm(), printer.io_rank());
-        const std::string out =
-            identifier() + " WCTime at step: " + std::to_string(step);
-        printer.echo(out + " " + timings);
+        const std::string out = identifier() + " step: " + std::to_string(step);
+        printer.echo(out + "\n" + timings);
     }
 
     long mem_usage();

--- a/src/OversetSimulation.h
+++ b/src/OversetSimulation.h
@@ -40,7 +40,7 @@ private:
     //! Parallel printer utility
     ParallelPrinter m_printer;
     //! Timer names
-    const std::vector<std::string> m_names{"TGConn"};
+    const std::vector<std::string> m_names{"Tioga"};
     //! Timers
     Timers m_timers;
 

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -7,6 +7,8 @@
 #include <chrono>
 #include <numeric>
 #include <cassert>
+#include <iomanip>
+#include <sstream>
 #include <string>
 
 namespace exawind {
@@ -114,19 +116,32 @@ struct Timers
         }
 
         MPI_Barrier(comm);
-        std::string out{""};
+        std::ostringstream outstream;
         const double ms2s = 1000.0;
+        const char separator = ' ';
+        const int name_width = 10;
+        const int num_width = 8;
         for (int i = 0; i < len; i++) {
-            out.append(
-                "  " + m_names.at(i) + ": " +
-                std::to_string(mintimes.at(i) / ms2s) + " " +
-                std::to_string(avgtimes.at(i) / ms2s) + " " +
-                std::to_string(maxtimes.at(i) / ms2s) + "\n");
+            outstream << "  " << std::left << std::setw(name_width)
+                      << std::setfill(separator) << m_names.at(i) + ":"
+                      << std::setw(num_width) << std::setfill(separator)
+                      << std::fixed << std::setprecision(4) << std::right
+                      << (mintimes.at(i) / ms2s) << std::setw(num_width)
+                      << std::setfill(separator) << std::fixed
+                      << std::setprecision(4) << std::right
+                      << (avgtimes.at(i) / ms2s) << std::setw(num_width)
+                      << std::setfill(separator) << std::fixed
+                      << std::setprecision(4) << std::right
+                      << (maxtimes.at(i) / ms2s) << std::endl;
         }
         const double total = std::accumulate(
             avgtimes.begin(), avgtimes.end(),
             decltype(avgtimes)::value_type(0.0));
-        out.append("  Total: " + std::to_string(total / ms2s));
+        outstream << "  " << std::left << std::setw(name_width)
+                  << std::setfill(separator) << "Total:" << std::setw(num_width)
+                  << std::setfill(separator) << std::fixed
+                  << std::setprecision(4) << std::right << (total / ms2s);
+        std::string out(outstream.str());
         return out;
     };
 };

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -118,14 +118,15 @@ struct Timers
         const double ms2s = 1000.0;
         for (int i = 0; i < len; i++) {
             out.append(
-                m_names.at(i) + ": " + std::to_string(mintimes.at(i) / ms2s) +
-                " " + std::to_string(avgtimes.at(i) / ms2s) + " " +
-                std::to_string(maxtimes.at(i) / ms2s) + " ");
+                "  " + m_names.at(i) + ": " +
+                std::to_string(mintimes.at(i) / ms2s) + " " +
+                std::to_string(avgtimes.at(i) / ms2s) + " " +
+                std::to_string(maxtimes.at(i) / ms2s) + "\n");
         }
         const double total = std::accumulate(
             avgtimes.begin(), avgtimes.end(),
             decltype(avgtimes)::value_type(0.0));
-        out.append("Total: " + std::to_string(total / ms2s));
+        out.append("  Total: " + std::to_string(total / ms2s));
         return out;
     };
 };


### PR DESCRIPTION
This looks like:
```
Step: 1
  Tioga: 0.002000 0.002000 0.002000
  Total: 0.002000
Nalu-Wind step: 1
  Pre: 0.000000 0.000000 0.000000
  PreConn: 0.000000 0.000500 0.001000
  PostConn: 0.001000 0.001000 0.001000
  Register: 0.000000 0.000000 0.000000
  Update: 0.000000 0.000000 0.000000
  Solve: 0.158000 0.158000 0.158000
  Post: 0.003000 0.003000 0.003000
  Total: 0.162500
AMR-Wind step: 1
  Pre: 0.000000 0.000000 0.000000
  PreConn: 0.000000 0.000500 0.001000
  PostConn: 0.005000 0.005500 0.006000
  Register: 0.006000 0.006000 0.006000
  Update: 0.006000 0.006500 0.007000
  Solve: 4.898000 4.898000 4.898000
  Post: 0.000000 0.000000 0.000000
  Total: 4.916500
Total: 5.086000

Nalu-Wind Memory Usage min: -1 avg: -1 max: -1 total: -2
AMR-Wind Memory Usage min: -1 avg: -1 max: -1 total: -2

Step: 2
```