### PR TITLE
remove default value

### DIFF
--- a/src/Timers.h
+++ b/src/Timers.h
@@ -23,7 +23,7 @@ class Timer
     TimeT _increment;
 
 public:
-    void tick(const bool incremental = true)
+    void tick(const bool incremental)
     {
         _start = ClockT::now();
         if ((incremental) && (_end != TimePt{})) {


### PR DESCRIPTION
Removing the default value of increment set to `true` . Note this function is wrapper around by the call from `struct Timers` which defaults the increment to `false`