### PR TITLE
remove averaging of nalu-wind timing

### DIFF
--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -206,20 +206,9 @@ void OversetSimulation::print_timing(const int nt)
         ParallelPrinter printer(ss->comm());
 
         // summary timings
-        if (ss->is_amr()) {
-            std::string timings_summary = ss->m_timers.get_timings_summary(
-                ss->identifier(), nt, ss->comm(), printer.io_rank());
-            printer.echo(timings_summary);
-        } else { // logic to add and average total time
-            std::vector<double> total_send(3, 0.0);
-            ss->m_timers.total_times(
-                total_send[0], total_send[1], total_send[2], ss->comm(),
-                printer.io_rank());
-
-            if (printer.is_io_rank()) {
-                MPI_Send(total_send.data(), 3, MPI_DOUBLE, 0, 0, m_comm);
-            }
-        }
+        std::string timings_summary = ss->m_timers.get_timings_summary(
+            ss->identifier(), nt, ss->comm(), printer.io_rank());
+        printer.echo(timings_summary);
 
         // detailed timings
         std::string timings_detail = ss->m_timers.get_timings_detail(
@@ -228,30 +217,6 @@ void OversetSimulation::print_timing(const int nt)
     }
 
     MPI_Barrier(m_comm);
-
-    // average nalu-wind total timings and print
-    if (m_printer.is_io_rank()) {
-        double nalu_total_min = 0.0, nalu_total_avg = 0.0, nalu_total_max = 0.0;
-        for (const auto& start_rank : m_nw_start_rank) {
-            std::vector<double> total_recv(3, 0.0);
-            MPI_Recv(
-                total_recv.data(), 3, MPI_DOUBLE, start_rank, 0, m_comm,
-                MPI_STATUS_IGNORE);
-
-            nalu_total_min += total_recv[0];
-            nalu_total_avg += total_recv[1];
-            nalu_total_max += total_recv[2];
-        }
-
-        nalu_total_min /= m_num_nw_solvers;
-        nalu_total_avg /= m_num_nw_solvers;
-        nalu_total_max /= m_num_nw_solvers;
-
-        std::ostringstream total_time_out = m_timers_exa.get_line_output(
-            "Nalu-Wind", nt, "Total", nalu_total_min, nalu_total_avg,
-            nalu_total_max);
-        m_printer.echo(total_time_out.str());
-    }
 }
 
 long OversetSimulation::mem_usage_all(const int step)


### PR DESCRIPTION
I and @jrood-nrel have noticed certain scenarios that result in some idling during MPI Send/Rcv put in to average timings across Nalu-Wind. I don't have much faith in the logic I put in, so removing it for now before anyone else runs into it.