### PR TITLE
Nalu Per/Eqn Timings

### DIFF
--- a/src/AMRWind.h
+++ b/src/AMRWind.h
@@ -46,6 +46,7 @@ protected:
     void post_overset_conn_work() override;
     void register_solution() override;
     void update_solution() override;
+    void dump_simulation_time() override{};
     MPI_Comm m_comm;
 };
 

--- a/src/ExawindSolver.h
+++ b/src/ExawindSolver.h
@@ -87,6 +87,8 @@ public:
         m_timers.tock(name);
     };
 
+    void call_dump_simulation_time() { dump_simulation_time(); };
+
     virtual bool is_unstructured() { return false; };
     virtual bool is_amr() { return false; };
     virtual int overset_update_interval() { return 100000000; };
@@ -115,6 +117,7 @@ protected:
     virtual void post_overset_conn_work() = 0;
     virtual void register_solution() = 0;
     virtual void update_solution() = 0;
+    virtual void dump_simulation_time() = 0;
 };
 
 } // namespace exawind

--- a/src/NaluWind.cpp
+++ b/src/NaluWind.cpp
@@ -137,4 +137,11 @@ int NaluWind::overset_update_interval()
 
 int NaluWind::time_index() { return m_sim.timeIntegrator_->timeStepCount_; }
 
+void NaluWind::dump_simulation_time()
+{
+    for (auto& realm : m_sim.timeIntegrator_->realmVec_) {
+        realm->dump_simulation_time();
+    }
+}
+
 } // namespace exawind

--- a/src/NaluWind.h
+++ b/src/NaluWind.h
@@ -59,6 +59,7 @@ protected:
     void post_overset_conn_work() override;
     void register_solution() override;
     void update_solution() override;
+    void dump_simulation_time() override;
     MPI_Comm m_comm;
 };
 

--- a/src/OversetSimulation.cpp
+++ b/src/OversetSimulation.cpp
@@ -168,7 +168,7 @@ void OversetSimulation::run_timesteps(const int add_pic_its, const int nsteps)
 
         mem_usage_all(nt);
     }
-
+    for (auto& ss : m_solvers) ss->call_dump_simulation_time();
     m_last_timestep = tend;
 }
 


### PR DESCRIPTION
Adding per equation timing dumps at the end of the nalu log files. This built and ran successfully on crusher. We now see stuff like the following at the end of a log file:


Timing for Eq: myNDTW
             init --    avg: 0.0261058    min: 0.025336  max: 0.0268435
         assemble --    avg: 0.0187556    min: 0.0175421    max: 0.0196021
    load_complete --    avg: 0.0622695    min: 0.061609  max: 0.0629308
            solve --    avg: 0.238173  min: 0.237964  max: 0.23845
    precond setup --    avg: 0.326766  min: 0.326711  max: 0.326934
             misc --    avg: 0   min: 0   max: 0
linear iterations --    avg: 22  min: 22  max: 22
Timing for Eq: myLowMach
             init --    avg: 2.56943e-05  min: 8.10623e-06  max: 6.34193e-05
         assemble --    avg: 0   min: 0   max: 0
    load_complete --    avg: 0   min: 0   max: 0
            solve --    avg: 0   min: 0   max: 0
    precond setup --    avg: 0   min: 0   max: 0
             misc --    avg: 0   min: 0   max: 0
Timing for Eq: MomentumEQS
             init --    avg: 0.0266768    min: 0.0258441    max: 0.0278006
         assemble --    avg: 3.63164   min: 3.49576   max: 3.85595
    load_complete --    avg: 2.4    min: 2.22711   max: 2.537
            solve --    avg: 10.0424   min: 10.0069   max: 10.0855
    precond setup --    avg: 5.93783e-05  min: 2.43187e-05  max: 8.65459e-05
             misc --    avg: 2.32892   min: 2.1715    max: 2.46475
linear iterations --    avg: 30.13  min: 17  max: 300
Timing for Eq: ContinuityEQS
             init --    avg: 0.0254965    min: 0.0244367    max: 0.0266006
         assemble --    avg: 2.43669   min: 2.3705    max: 2.49266
    load_complete --    avg: 1.73952   min: 1.68266   max: 1.7997
            solve --    avg: 50.7579   min: 50.7242   max: 50.7995
    precond setup --    avg: 135.719   min: 135.709   max: 135.734
             misc --    avg: 2.80556   min: 2.59183   max: 2.87766
linear iterations --    avg: 12.295    min: 11  max: 100