### PR TITLE
Allow specification of different number of ranks for nalu instances

### DIFF
--- a/app/exawind/exawind.cpp
+++ b/app/exawind/exawind.cpp
@@ -104,9 +104,8 @@ int main(int argc, char** argv)
                 " number of Nalu-Wind solvers. Please have one rank count "
                 "specification per solver");
         }
-        const int tot_num_nw_ranks =
-            std::accumulate(num_nw_solver_ranks.begin(),
-                            num_nw_solver_ranks.end(), 0);
+        const int tot_num_nw_ranks = std::accumulate(
+            num_nw_solver_ranks.begin(), num_nw_solver_ranks.end(), 0);
         if (tot_num_nw_ranks != num_nwind_ranks) {
             throw std::runtime_error(
                 "Total number of Nalu-Wind ranks does not "

--- a/app/exawind/exawind.cpp
+++ b/app/exawind/exawind.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
                 "specification per solver");
         }
         int tot_num_nw_ranks = 0;
-        for(std::vector<int>::iterator nwr = num_nw_solver_ranks.begin();
+        for (std::vector<int>::iterator nwr = num_nw_solver_ranks.begin();
             nwr != num_nw_solver_ranks.end(); ++nwr) {
             tot_num_nw_ranks += *nwr;
         }
@@ -117,13 +117,13 @@ int main(int argc, char** argv)
         }
     } else {
         const int ranks_per_nw_solver = num_nwind_ranks / num_nwsolvers;
-        num_nw_solver_ranks = std::vector<int>(num_nwsolvers,
-                                               ranks_per_nw_solver);
+        num_nw_solver_ranks =
+            std::vector<int>(num_nwsolvers, ranks_per_nw_solver);
         const int remainder = num_nwind_ranks % num_nwsolvers;
         if (remainder != 0) {
             std::fill(
-                      num_nw_solver_ranks.begin() + num_nwsolvers - remainder,
-                      num_nw_solver_ranks.end(), ranks_per_nw_solver + 1);
+                num_nw_solver_ranks.begin() + num_nwsolvers - remainder,
+                num_nw_solver_ranks.end(), ranks_per_nw_solver + 1);
         }
     }
     const int ranks_per_nw_solver = num_nwind_ranks / num_nwsolvers;

--- a/app/exawind/exawind.cpp
+++ b/app/exawind/exawind.cpp
@@ -126,14 +126,6 @@ int main(int argc, char** argv)
                 num_nw_solver_ranks.end(), ranks_per_nw_solver + 1);
         }
     }
-    const int ranks_per_nw_solver = num_nwind_ranks / num_nwsolvers;
-    std::vector<int> num_nw_solver_ranks(num_nwsolvers, ranks_per_nw_solver);
-    const int remainder = num_nwind_ranks % num_nwsolvers;
-    if (remainder != 0) {
-        std::fill(
-            num_nw_solver_ranks.begin() + num_nwsolvers - remainder,
-            num_nw_solver_ranks.end(), ranks_per_nw_solver + 1);
-    }
 
     if (!use_amr_wind) {
         num_awind_ranks = 0;

--- a/app/exawind/exawind.cpp
+++ b/app/exawind/exawind.cpp
@@ -95,6 +95,37 @@ int main(int argc, char** argv)
             "Number of Nalu-Wind ranks is less than the number of Nalu-Wind "
             "solvers. Please have at least one rank per solver.");
     }
+    std::vector<int> num_nw_solver_ranks;
+    if(node["nalu_wind_procs"]) {
+        num_nw_solver_ranks = node["nalu_wind_procs"].as<std::vector<int>>();
+        if (num_nw_solver_ranks.size() != num_nwsolvers) {
+            throw std::runtime_error(
+                "Number of Nalu-Wind rank specifications is less than the "
+                " number of Nalu-Wind solvers. Please have one rank count "
+                "specification per solver");
+        }
+        int tot_num_nw_ranks = 0;
+        for(std::vector<int>::iterator nwr = num_nw_solver_ranks.begin();
+            nwr != num_nw_solver_ranks.end(); ++nwr) {
+            tot_num_nw_ranks += *nwr;
+        }
+        if (tot_num_nw_ranks != num_nwind_ranks) {
+            throw std::runtime_error(
+                "Total number of Nalu-Wind ranks does not "
+                "match that given in the command line. Please ensure "
+                "they match");
+        }
+    } else {
+        const int ranks_per_nw_solver = num_nwind_ranks / num_nwsolvers;
+        num_nw_solver_ranks = std::vector<int>(num_nwsolvers,
+                                               ranks_per_nw_solver);
+        const int remainder = num_nwind_ranks % num_nwsolvers;
+        if (remainder != 0) {
+            std::fill(
+                      num_nw_solver_ranks.begin() + num_nwsolvers - remainder,
+                      num_nw_solver_ranks.end(), ranks_per_nw_solver + 1);
+        }
+    }
     const int ranks_per_nw_solver = num_nwind_ranks / num_nwsolvers;
     std::vector<int> num_nw_solver_ranks(num_nwsolvers, ranks_per_nw_solver);
     const int remainder = num_nwind_ranks % num_nwsolvers;

--- a/app/exawind/exawind.cpp
+++ b/app/exawind/exawind.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
             "solvers. Please have at least one rank per solver.");
     }
     std::vector<int> num_nw_solver_ranks;
-    if(node["nalu_wind_procs"]) {
+    if (node["nalu_wind_procs"]) {
         num_nw_solver_ranks = node["nalu_wind_procs"].as<std::vector<int>>();
         if (num_nw_solver_ranks.size() != num_nwsolvers) {
             throw std::runtime_error(
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
         }
         int tot_num_nw_ranks = 0;
         for (std::vector<int>::iterator nwr = num_nw_solver_ranks.begin();
-            nwr != num_nw_solver_ranks.end(); ++nwr) {
+             nwr != num_nw_solver_ranks.end(); ++nwr) {
             tot_num_nw_ranks += *nwr;
         }
         if (tot_num_nw_ranks != num_nwind_ranks) {

--- a/app/exawind/exawind.cpp
+++ b/app/exawind/exawind.cpp
@@ -104,11 +104,9 @@ int main(int argc, char** argv)
                 " number of Nalu-Wind solvers. Please have one rank count "
                 "specification per solver");
         }
-        int tot_num_nw_ranks = 0;
-        for (std::vector<int>::iterator nwr = num_nw_solver_ranks.begin();
-             nwr != num_nw_solver_ranks.end(); ++nwr) {
-            tot_num_nw_ranks += *nwr;
-        }
+        const int tot_num_nw_ranks =
+            std::accumulate(num_nw_solver_ranks.begin(),
+                            num_nw_solver_ranks.end(), 0);
         if (tot_num_nw_ranks != num_nwind_ranks) {
             throw std::runtime_error(
                 "Total number of Nalu-Wind ranks does not "


### PR DESCRIPTION
Adds a new section in the yaml input file called `nalu_wind_procs` that allows different number of processors to be specified for different nalu-wind instances. Allows for backward compatibility where if the new section on `nalu_wind_procs` is not specified, then it reverts back to original functionality where the argument of `--nwind` is evenly split across all nalu-wind instances.

```# Example input file

exawind:
  nalu_wind_inp:
    - cylinder-nalu-far.yaml
    - cylinder-nalu-near.yaml
  nalu_wind_procs:
    - 36
    - 23
  num_timesteps: 10
  additional_picard_iterations: 2

  # Variables for overset exchange
  nalu_vars:
    - velocity
    - pressure
```