### PR TITLE
Test case that shows problem with Nalu-Tioga link

### DIFF
--- a/test/test_files/tioga-test/milestone.xml
+++ b/test/test_files/tioga-test/milestone.xml
@@ -1,0 +1,22 @@
+<ParameterList name="MueLu">
+  <Parameter        name="verbosity"                        type="string"   value="none"/>
+  <Parameter        name="coarse: max size"                 type="int"      value="1000"/>
+
+  <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
+  <ParameterList    name="smoother: params">
+     <Parameter name="chebyshev: degree"                    type="int"      value="2"/>
+     <Parameter name="chebyshev: ratio eigenvalue"          type="double"   value="20"/>
+     <Parameter name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+     <Parameter name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+     <Parameter name="chebyshev: eigenvalue max iterations" type="int"      value="15"/>
+  </ParameterList>
+
+  <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
+  <Parameter        name="aggregation: drop tol"            type="double"   value="0.02"/>
+
+  <Parameter        name="repartition: enable"              type="bool"     value="true"/>
+  <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>
+  <Parameter        name="repartition: start level"         type="int"      value="2"/>
+  <Parameter        name="repartition: max imbalance"       type="double"   value="1.327"/>
+  <Parameter        name="repartition: partitioner"         type="string"   value="zoltan2"/>
+</ParameterList>

--- a/test/test_files/tioga-test/tiogatest-amr.inp
+++ b/test/test_files/tioga-test/tiogatest-amr.inp
@@ -2,18 +2,19 @@
 #            SIMULATION STOP            #
 #.......................................#
 time.stop_time               =   -100.0     # Max (simulated) time to evolve
-time.max_step                =   1           # Max number of time steps
+time.max_step                =   1          # Max number of time steps
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #
 #.......................................#
 time.fixed_dt         =   0.5        # Use this constant dt if > 0
 time.cfl              =   0.95         # CFL factor
+incflo.prescribe_velocity = true
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#
-time.plot_interval            =  1        # Steps between plot files
+time.plot_interval            =  1       # Steps between plot files
 time.checkpoint_interval      =  -1       # Steps between checkpoint files
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
@@ -21,8 +22,7 @@ time.checkpoint_interval      =  -1       # Steps between checkpoint files
 #.......................................#
 ConstValue.density.value = 1.5
 ConstValue.p.value = 2.0
-LinearProfile.velocity.start_val = 0.0 0.0 0.0
-LinearProfile.velocity.stop_val = 1.0 0.5 0.0
+ConstValue.velocity.value = 0.1 -0.1 0.0
 
 incflo.use_godunov = 1
 incflo.diffusion_type = 2
@@ -34,7 +34,6 @@ transport.turbulent_prandtl = 0.3333
 turbulence.model = Laminar
 
 incflo.physics = FreeStream
-FreeStream.velocity_type = LinearProfile
 
 amr.n_cell              =  64 64 64    # Grid cells at coarsest AMRlevel
 amr.max_level           =  0           # Max AMR level in hierarchy

--- a/test/test_files/tioga-test/tiogatest-amr.inp
+++ b/test/test_files/tioga-test/tiogatest-amr.inp
@@ -2,7 +2,7 @@
 #            SIMULATION STOP            #
 #.......................................#
 time.stop_time               =   -100.0     # Max (simulated) time to evolve
-time.max_step                =   10          # Max number of time steps
+time.max_step                =   1           # Max number of time steps
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #
@@ -13,7 +13,7 @@ time.cfl              =   0.95         # CFL factor
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#
-time.plot_interval            =  10       # Steps between plot files
+time.plot_interval            =  1        # Steps between plot files
 time.checkpoint_interval      =  -1       # Steps between checkpoint files
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/test/test_files/tioga-test/tiogatest-amr.inp
+++ b/test/test_files/tioga-test/tiogatest-amr.inp
@@ -21,7 +21,6 @@ time.checkpoint_interval      =  -1       # Steps between checkpoint files
 #               PHYSICS                 #
 #.......................................#
 ConstValue.density.value = 1.5
-ConstValue.p.value = 2.0
 ConstValue.velocity.value = 0.1 -0.1 0.0
 
 incflo.use_godunov = 1

--- a/test/test_files/tioga-test/tiogatest-amr.inp
+++ b/test/test_files/tioga-test/tiogatest-amr.inp
@@ -1,0 +1,51 @@
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            SIMULATION STOP            #
+#.......................................#
+time.stop_time               =   -100.0     # Max (simulated) time to evolve
+time.max_step                =   10          # Max number of time steps
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#         TIME STEP COMPUTATION         #
+#.......................................#
+time.fixed_dt         =   0.5        # Use this constant dt if > 0
+time.cfl              =   0.95         # CFL factor
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            INPUT AND OUTPUT           #
+#.......................................#
+time.plot_interval            =  10       # Steps between plot files
+time.checkpoint_interval      =  -1       # Steps between checkpoint files
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#               PHYSICS                 #
+#.......................................#
+ConstValue.density.value = 1.5
+ConstValue.p.value = 2.0
+LinearProfile.velocity.start_val = 0.0 0.0 0.0
+LinearProfile.velocity.stop_val = 1.0 0.5 0.0
+
+incflo.use_godunov = 1
+incflo.diffusion_type = 2
+incflo.do_initial_proj = 0
+incflo.initial_iterations = 0
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Laminar
+
+incflo.physics = FreeStream
+FreeStream.velocity_type = LinearProfile
+
+amr.n_cell              =  64 64 64    # Grid cells at coarsest AMRlevel
+amr.max_level           =  0           # Max AMR level in hierarchy
+geometry.prob_lo        =   -0.5  -0.5  -0.5   # Lo corner coordinates
+geometry.prob_hi        =    0.5   0.5   0.5   # Hi corner coordinates
+geometry.is_periodic    =    1  1  1   # Periodicity x y z (0/1)
+
+incflo.verbose          =   0          # incflo_level
+nodal_proj.verbose = 0
+mac_proj.max_coarsening_level = 0
+mac_proj.bottom_solver = hypre
+nodal_proj.max_coarsening_level = 0
+nodal_proj.bottom_solver = hypre
+

--- a/test/test_files/tioga-test/tiogatest-nalu.yaml
+++ b/test/test_files/tioga-test/tiogatest-nalu.yaml
@@ -1,0 +1,119 @@
+Simulations:
+  - name: sim1
+    time_integrator: ti_1
+    optimizer: opt1
+
+linear_solvers:
+
+  - name: solve_scalar
+    type: tpetra
+    method: gmres
+    preconditioner: sgs
+    tolerance: 1e-12
+    max_iterations: 50
+    kspace: 50
+    output_level: 0
+
+  - name: solve_cont
+    type: tpetra
+    method: gmres
+    preconditioner: muelu
+    tolerance: 1e-7
+    max_iterations: 150
+    kspace: 75
+    output_level: 0
+    recompute_preconditioner: yes
+    muelu_xml_file_name: milestone.xml
+
+realms:
+
+  - name: realm_1
+    mesh: tilted_hex_biggerangle.exo
+    use_edges: yes
+    automatic_decomposition_type: rcb
+    #rebalance_mesh: yes
+    #stk_rebalance_method: parmetis
+    check_for_missing_bcs: yes
+
+    equation_systems:
+      name: theEqSys
+      max_iterations: 1
+      decoupled_overset_solve: yes
+
+      solver_system_specification:
+        velocity: solve_scalar
+        pressure: solve_cont
+
+      systems:
+        - LowMachEOM:
+            name: myLowMach
+            max_iterations: 1
+            convergence_tolerance: 1e-8
+
+    initial_conditions:
+
+      - constant: ic_1
+        target_name: block-HEX
+        value:
+          velocity: [0.0, 0.0, 0.0]
+          pressure: 0.0
+
+    material_properties:
+      target_name: block-HEX
+      specifications:
+        - name: density
+          type: constant
+          value: 1.0
+
+        - name: viscosity
+          type: constant
+          value: 1.0e-5
+
+    boundary_conditions:
+
+      - overset_boundary_condition: bc_overset
+        overset_connectivity_type: tioga
+        overset_user_data:
+          tioga_options:
+            set_resolutions: no
+          mesh_group:
+            - overset_name: oset_n
+              mesh_parts: [block-HEX]
+              ovset_parts: [outer_surf]
+
+    solution_options:
+      name: myOptions
+
+      options:
+        - hybrid_factor:
+            velocity: 0.05
+
+        - upw_factor:
+            velocity: 0.0
+    
+        - consistent_mass_matrix_png:
+            pressure: no
+
+    output:
+      output_data_base_name: out/tiogaTest.e
+      output_frequency: 1
+      output_node_set: yes
+      output_variables:
+       - density
+       - velocity
+       - pressure
+       - iblank
+       - iblank_cell
+Time_Integrators:
+  - StandardTimeIntegrator:
+      name: ti_1
+      start_time: 0.0
+      termination_time: 0.0005
+      time_step: 0.0005
+      time_stepping_type: fixed
+      time_step_count: 0
+      second_order_accuracy: yes
+
+
+      realms:
+        - realm_1

--- a/test/test_files/tioga-test/tiogatest.yaml
+++ b/test/test_files/tioga-test/tiogatest.yaml
@@ -1,0 +1,17 @@
+
+exawind:
+  nalu_wind_inp:
+    - tiogatest-nalu.yaml
+  amr_wind_inp: tiogatest-amr.inp
+  num_timesteps: 1
+  additional_picard_iterations: 0
+
+  nalu_vars:
+    - velocity
+    - density
+    - pressure
+  amr_cell_vars:
+    - velocity
+    - density
+  amr_node_vars:
+    - p


### PR DESCRIPTION
In Nalu-Wind, the velocity is set to 0.0 and the density is set to 1.0. In AMR-Wind, the velocity is set to [0.1, -0.1, 0.0] and the density is set to 1.5. This shows that when multiple processors are used for Nalu-Wind, there are errors in communicating the fields properly into Nalu-Wind. The iblank field (its boundary shown in black), does not have issues, though, thanks to the recent changes to Nalu-Wind.

![Screenshot 2024-03-22 at 2 03 30 PM](https://github.com/Exawind/exawind-driver/assets/31661049/ff2bdf8e-5498-4ba9-9140-597d7395a304)
