### PR TITLE
Add boundary plane regression test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,13 @@ function(add_test_r TEST_NAME)
                          ATTACHED_FILES "${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.log")
 endfunction(add_test_r)
 
+# Regression test with dependency
+function(add_test_rd TEST_NAME TEST_DEPENDENCY)
+    add_test_r(${TEST_NAME})
+    set_tests_properties(${TEST_NAME} PROPERTIES FIXTURES_REQUIRED fixture_${TEST_DEPENDENCY})
+    set_tests_properties(${TEST_DEPENDENCY} PROPERTIES FIXTURES_SETUP fixture_${TEST_DEPENDENCY})
+endfunction(add_test_rd)
+
 #=============================================================================
 # Regression tests
 #=============================================================================
@@ -68,3 +75,6 @@ add_test_r(sloshing-tank)
 add_test_r(linear-waves)
 add_test_r(stokes-waves-cylinder)
 add_test_r(dam-break-block)
+
+add_test_r(abl-bndry-output)
+add_test_rd(abl-bndry-input abl-bndry-output)

--- a/test/test_files/abl-bndry-input/abl-amr-bndry-input.inp
+++ b/test/test_files/abl-bndry-input/abl-amr-bndry-input.inp
@@ -1,0 +1,81 @@
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            SIMULATION STOP            #
+#.......................................#
+time.stop_time               =   22000.0     # Max (simulated) time to evolve
+time.max_step                =   10          # Max number of time steps
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#         TIME STEP COMPUTATION         #
+#.......................................#
+time.fixed_dt         =   0.4        # Use this constant dt if > 0
+time.cfl              =   0.95         # CFL factor
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            INPUT AND OUTPUT           #
+#.......................................#
+io.restart_file = "../abl-bndry-output/chk00005"
+time.plot_interval            =  10       # Steps between plot files
+time.checkpoint_interval      =  -1       # Steps between checkpoint files
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#               PHYSICS                 #
+#.......................................#
+incflo.gravity          =   0.  0. -9.81  # Gravitational force (3D)
+incflo.density          = 1.0          # Reference density
+incflo.use_godunov = 1
+incflo.diffusion_type = 2
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
+incflo.physics = ABL
+ICNS.source_terms = CoriolisForcing GeostrophicForcing
+ABL.reference_temperature = 290.0
+CoriolisForcing.east_vector = 1.0 0.0 0.0
+CoriolisForcing.north_vector = 0.0 1.0 0.0
+CoriolisForcing.latitude = 90.0
+CoriolisForcing.rotational_time_period = 125663.706143592
+GeostrophicForcing.geostrophic_wind = 10.0 0.0 0.0
+incflo.velocity = 10.0 0.0 0.0
+ABL.temperature_heights = 0.0 2000.0
+ABL.temperature_values = 290.0 290.0
+ABL.perturb_temperature = false
+ABL.cutoff_height = 50.0
+ABL.perturb_velocity = true
+ABL.perturb_ref_height = 50.0
+ABL.Uperiods = 4.0
+ABL.Vperiods = 4.0
+ABL.deltaU = 1.0
+ABL.deltaV = 1.0
+ABL.kappa = .41
+ABL.surface_roughness_z0 = 0.01
+ABL.bndry_file = "../abl-bndry-output/bndry_files"
+ABL.bndry_io_mode = 1
+ABL.bndry_var_names = velocity temperature
+ABL.bndry_output_format = native
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#        ADAPTIVE MESH REFINEMENT       #
+#.......................................#
+amr.n_cell              = 48 48 48    # Grid cells at coarsest AMRlevel
+amr.max_level           = 0           # Max AMR level in hierarchy 
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              GEOMETRY                 #
+#.......................................#
+geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
+geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
+geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
+# Boundary conditions
+xlo.type = "mass_inflow"
+xlo.density = 1.0
+xlo.temperature = 0.0
+xhi.type = "pressure_outflow"
+ylo.type = "mass_inflow"
+ylo.density = 1.0
+ylo.temperature = 0.0
+yhi.type = "pressure_outflow"
+zlo.type =   "wall_model"
+zhi.type =   "slip_wall"
+zhi.temperature_type = "fixed_gradient"
+zhi.temperature = 0.0
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              VERBOSITY                #
+#.......................................#
+incflo.verbose          =   0          # incflo_level

--- a/test/test_files/abl-bndry-input/abl-bndry-input.yaml
+++ b/test/test_files/abl-bndry-input/abl-bndry-input.yaml
@@ -1,0 +1,15 @@
+
+exawind:
+  nalu_wind_inp:
+    - abl-nalu-box-rst.yaml
+  amr_wind_inp: abl-amr-bndry-input.inp
+  num_timesteps: 5
+  additional_picard_iterations: 2
+
+  nalu_vars:
+    - velocity
+    - pressure
+  amr_cell_vars:
+    - velocity
+  amr_node_vars:
+    - p

--- a/test/test_files/abl-bndry-input/abl-nalu-box-rst.yaml
+++ b/test/test_files/abl-bndry-input/abl-nalu-box-rst.yaml
@@ -1,0 +1,121 @@
+Simulations:
+  - name: sim1
+    time_integrator: ti_1
+    optimizer: opt1
+
+linear_solvers:
+
+  - name: solve_scalar
+    type: hypre
+    method: hypre_gmres
+    preconditioner: boomerAMG
+    tolerance: 1e-5
+    max_iterations: 200
+    kspace: 5
+    bamg_relax_type: 18
+    bamg_max_levels: 1
+
+  - name: solve_cont
+    type: hypre
+    method: hypre_gmres
+    preconditioner: boomerAMG
+    tolerance: 1e-5
+    max_iterations: 200
+    kspace: 5
+    bamg_relax_type: 18
+    bamg_max_levels: 1
+
+realms:
+
+  - name: realm_1
+    mesh: "../abl-bndry-output/ablBox.rst"
+    use_edges: yes
+    check_for_missing_bcs: yes
+
+    equation_systems:
+      name: theEqSys
+      max_iterations: 1
+      decoupled_overset_solve: yes
+
+      solver_system_specification:
+        volume_of_fluid: solve_scalar
+        velocity: solve_scalar
+        pressure: solve_cont
+
+      systems:
+        - LowMachEOM:
+            name: myLowMach
+            max_iterations: 1
+            convergence_tolerance: 1e-8
+
+    initial_conditions:
+
+      - constant: ic_1
+        target_name: block_1
+        value:
+          velocity: [10.0, 0.0, 0.0]
+          pressure: 0.0
+
+    material_properties:
+      target_name: block_1
+      specifications:
+        - name: density
+          type: constant
+          value: 1.0
+
+        - name: viscosity
+          type: constant
+          value: 1.0e-5
+
+    boundary_conditions:
+
+      - overset_boundary_condition: bc_overset
+        overset_connectivity_type: tioga
+        overset_user_data:
+          tioga_options:
+            set_resolutions: no
+          mesh_group:
+            - overset_name: oset_n
+              mesh_parts: [block_1]
+              ovset_parts: [surface_1,surface_2,surface_3,surface_4,surface_5,surface_6]
+
+    solution_options:
+      name: myOptions
+
+      options:
+        - hybrid_factor:
+            velocity: 1.0
+
+        - upw_factor:
+            velocity: 1.0
+    
+        - consistent_mass_matrix_png:
+            pressure: no
+
+        - user_constants:
+            reference_density: 0.00
+            gravity: [0.0, 0.0, -9.81]
+
+    restart:
+      restart_time: 2.5
+
+    output:
+      output_data_base_name: out/ablBox.e
+      output_frequency: 5
+      output_node_set: yes
+      output_variables:
+       - density
+       - velocity
+       - pressure
+       - iblank
+Time_Integrators:
+  - StandardTimeIntegrator:
+      name: ti_1
+      termination_time: 200.0
+      time_step: 0.4
+      time_stepping_type: fixed
+      second_order_accuracy: yes
+
+
+      realms:
+        - realm_1

--- a/test/test_files/abl-bndry-output/abl-amr-bndry-output.inp
+++ b/test/test_files/abl-bndry-output/abl-amr-bndry-output.inp
@@ -1,0 +1,75 @@
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            SIMULATION STOP            #
+#.......................................#
+time.stop_time               =   22000.0     # Max (simulated) time to evolve
+time.max_step                =   10          # Max number of time steps
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#         TIME STEP COMPUTATION         #
+#.......................................#
+time.fixed_dt         =   0.5        # Use this constant dt if > 0
+time.cfl              =   0.95         # CFL factor
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            INPUT AND OUTPUT           #
+#.......................................#
+time.plot_interval            =  10       # Steps between plot files
+time.checkpoint_interval      =  5       # Steps between checkpoint files
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#               PHYSICS                 #
+#.......................................#
+incflo.gravity          =   0.  0. -9.81  # Gravitational force (3D)
+incflo.density          = 1.0          # Reference density
+incflo.use_godunov = 1
+incflo.diffusion_type = 2
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
+incflo.physics = ABL
+ICNS.source_terms = CoriolisForcing GeostrophicForcing
+ABL.reference_temperature = 290.0
+CoriolisForcing.east_vector = 1.0 0.0 0.0
+CoriolisForcing.north_vector = 0.0 1.0 0.0
+CoriolisForcing.latitude = 90.0
+CoriolisForcing.rotational_time_period = 125663.706143592
+GeostrophicForcing.geostrophic_wind = 10.0 0.0 0.0
+incflo.velocity = 10.0 0.0 0.0
+ABL.temperature_heights = 0.0 2000.0
+ABL.temperature_values = 290.0 290.0
+ABL.perturb_temperature = false
+ABL.cutoff_height = 50.0
+ABL.perturb_velocity = true
+ABL.perturb_ref_height = 50.0
+ABL.Uperiods = 4.0
+ABL.Vperiods = 4.0
+ABL.deltaU = 1.0
+ABL.deltaV = 1.0
+ABL.kappa = .41
+ABL.surface_roughness_z0 = 0.01
+ABL.bndry_file = "bndry_files"
+ABL.bndry_io_mode = 0
+ABL.bndry_planes = ylo xlo yhi xhi
+ABL.bndry_output_start_time = 2.0
+ABL.bndry_var_names = velocity temperature
+ABL.bndry_output_format = native
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#        ADAPTIVE MESH REFINEMENT       #
+#.......................................#
+amr.n_cell              = 48 48 48    # Grid cells at coarsest AMRlevel
+amr.max_level           = 0           # Max AMR level in hierarchy 
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              GEOMETRY                 #
+#.......................................#
+geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
+geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
+geometry.is_periodic    =   1   1   0   # Periodicity x y z (0/1)
+# Boundary conditions
+zlo.type =   "wall_model"
+
+zhi.type =   "slip_wall"
+zhi.temperature_type = "fixed_gradient"
+zhi.temperature = 0.0
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              VERBOSITY                #
+#.......................................#
+incflo.verbose          =   0          # incflo_level

--- a/test/test_files/abl-bndry-output/abl-bndry-output.yaml
+++ b/test/test_files/abl-bndry-output/abl-bndry-output.yaml
@@ -1,0 +1,15 @@
+
+exawind:
+  nalu_wind_inp:
+    - abl-nalu-box.yaml
+  amr_wind_inp: abl-amr-bndry-output.inp
+  num_timesteps: 10
+  additional_picard_iterations: 2
+
+  nalu_vars:
+    - velocity
+    - pressure
+  amr_cell_vars:
+    - velocity
+  amr_node_vars:
+    - p

--- a/test/test_files/abl-bndry-output/abl-nalu-box.yaml
+++ b/test/test_files/abl-bndry-output/abl-nalu-box.yaml
@@ -1,0 +1,125 @@
+Simulations:
+  - name: sim1
+    time_integrator: ti_1
+    optimizer: opt1
+
+linear_solvers:
+
+  - name: solve_scalar
+    type: hypre
+    method: hypre_gmres
+    preconditioner: boomerAMG
+    tolerance: 1e-5
+    max_iterations: 200
+    kspace: 5
+    bamg_relax_type: 18
+    bamg_max_levels: 1
+
+  - name: solve_cont
+    type: hypre
+    method: hypre_gmres
+    preconditioner: boomerAMG
+    tolerance: 1e-5
+    max_iterations: 200
+    kspace: 5
+    bamg_relax_type: 18
+    bamg_max_levels: 1
+
+realms:
+
+  - name: realm_1
+    mesh: "generated:8x8x8|bbox:100.,100.,100.,270.,270.,270.|sideset:xXyYzZ|show"
+    use_edges: yes
+    automatic_decomposition_type: rcb
+    check_for_missing_bcs: yes
+
+    equation_systems:
+      name: theEqSys
+      max_iterations: 1
+      decoupled_overset_solve: yes
+
+      solver_system_specification:
+        volume_of_fluid: solve_scalar
+        velocity: solve_scalar
+        pressure: solve_cont
+
+      systems:
+        - LowMachEOM:
+            name: myLowMach
+            max_iterations: 1
+            convergence_tolerance: 1e-8
+
+    initial_conditions:
+
+      - constant: ic_1
+        target_name: block_1
+        value:
+          velocity: [10.0, 0.0, 0.0]
+          pressure: 0.0
+
+    material_properties:
+      target_name: block_1
+      specifications:
+        - name: density
+          type: constant
+          value: 1.0
+
+        - name: viscosity
+          type: constant
+          value: 1.0e-5
+
+    boundary_conditions:
+
+      - overset_boundary_condition: bc_overset
+        overset_connectivity_type: tioga
+        overset_user_data:
+          tioga_options:
+            set_resolutions: no
+          mesh_group:
+            - overset_name: oset_n
+              mesh_parts: [block_1]
+              ovset_parts: [surface_1,surface_2,surface_3,surface_4,surface_5,surface_6]
+
+    solution_options:
+      name: myOptions
+
+      options:
+        - hybrid_factor:
+            velocity: 1.0
+
+        - upw_factor:
+            velocity: 1.0
+    
+        - consistent_mass_matrix_png:
+            pressure: no
+
+        - user_constants:
+            reference_density: 0.00
+            gravity: [0.0, 0.0, -9.81]
+
+    restart:
+      restart_data_base_name: ablBox.rst
+      restart_frequency: 5
+      restart_start: 0
+
+    output:
+      output_data_base_name: out/ablBox.e
+      output_frequency: 5
+      output_node_set: yes
+      output_variables:
+       - density
+       - velocity
+       - pressure
+       - iblank
+Time_Integrators:
+  - StandardTimeIntegrator:
+      name: ti_1
+      termination_time: 200.0
+      time_step: 0.5
+      time_stepping_type: fixed
+      time_step_count: 0
+      second_order_accuracy: yes
+
+
+      realms:
+        - realm_1


### PR DESCRIPTION
Need to make sure this important capability is covered. The uniqueness of the file reads and using the overset solver make it prone to being accidentally broken.

Should follow after the merge of https://github.com/Exawind/amr-wind/pull/1358