### PR TITLE
Coarsen two-phase reg tests to speed them up

### DIFF
--- a/test/test_files/dam-break-block/dam-break-block-amr.inp
+++ b/test/test_files/dam-break-block/dam-break-block-amr.inp
@@ -1,8 +1,9 @@
 time.stop_time               =   2     # Max (simulated) time to evolve
 time.max_step                =   2000          # Max number of time steps
 
-time.fixed_dt         =   0.001        # Use this constant dt if > 0
-time.cfl              =   0.95         # CFL factor
+time.fixed_dt         =   0.005        # Use this constant dt if > 0
+time.cfl              =   1.0         # CFL factor
+time.use_force_cfl    =   false
 
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -1       # Steps between checkpoint files
@@ -22,16 +23,16 @@ mac_proj.max_coarsening_level = 2
 incflo.physics = MultiPhase DamBreak 
 MultiPhase.density_fluid1=1000.
 MultiPhase.density_fluid2=1.
-DamBreak.location = -0.8 0.0 -0.3125
-DamBreak.width    = 0.5
-DamBreak.height   = 0.8
+DamBreak.location = -0.35 0.0 -0.3125
+DamBreak.width    = 0.15
+DamBreak.height   = 0.7
 ICNS.source_terms = GravityForcing 
 
-amr.n_cell              = 64 16 32    # Grid cells at coarsest AMRlevel
+amr.n_cell              = 32 16 32    # Grid cells at coarsest AMRlevel
 amr.max_level           = 0           # Max AMR level in hierarchy 
 
-geometry.prob_lo        =   -1.4  -0.375 -0.3125  # Lo corner coordinates
-geometry.prob_hi        =   1.1 0.375 1.1875  # Hi corner coordinates
+geometry.prob_lo        =   -0.4  -0.375 -0.3125  # Lo corner coordinates
+geometry.prob_hi        =   0.35 0.375 0.4375  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
 
 xlo.type =   "slip_wall"

--- a/test/test_files/dam-break-block/dam-break-block-nalu.yaml
+++ b/test/test_files/dam-break-block/dam-break-block-nalu.yaml
@@ -132,7 +132,7 @@ Time_Integrators:
       name: ti_1
       start_time: 0.0
       termination_time: 2.0
-      time_step: 0.001
+      time_step: 0.005
       time_stepping_type: fixed
       time_step_count: 0
       second_order_accuracy: yes

--- a/test/test_files/flat-surface/flat-surface-amr.inp
+++ b/test/test_files/flat-surface/flat-surface-amr.inp
@@ -2,7 +2,7 @@ time.stop_time               =   2     # Max (simulated) time to evolve
 time.max_step                =   -10    # Max number of time steps
 
 time.initial_dt       =   -0.05   
-time.fixed_dt         =   0.0005
+time.fixed_dt         =   0.001
 time.cfl              =   0.95
 time.plot_interval    =   10  
 incflo.do_initial_proj    = 0
@@ -30,7 +30,7 @@ ICNS.use_perturb_pressure = false
 Overset.verbose = 1
 nodal_proj.max_coarsening_level = 2
 
-amr.n_cell              = 64 64 64   # Grid cells at coarsest AMRlevel
+amr.n_cell              = 32 32 32   # Grid cells at coarsest AMRlevel
 amr.max_level = 0
 
 geometry.prob_lo        =   -0.5  -0.5  -0.5   # Lo corner coordinates

--- a/test/test_files/flat-surface/flat-surface-nalu.yaml
+++ b/test/test_files/flat-surface/flat-surface-nalu.yaml
@@ -28,7 +28,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: "generated:48x48x48|bbox:-0.25,-0.25,-0.25,0.25,0.25,0.25|sideset:xXyYzZ|show"
+    mesh: "generated:24x24x24|bbox:-0.25,-0.25,-0.25,0.25,0.25,0.25|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
     check_for_missing_bcs: yes
@@ -118,7 +118,7 @@ realms:
             
     output:
       output_data_base_name: out/flatSurface.e
-      output_frequency: 5
+      output_frequency: 10
       output_node_set: yes
       output_variables:
        - density
@@ -133,7 +133,7 @@ Time_Integrators:
       name: ti_1
       start_time: 0.0
       termination_time: 2.0
-      time_step: 0.0005
+      time_step: 0.001
       time_stepping_type: fixed
       time_step_count: 0
       second_order_accuracy: yes

--- a/test/test_files/linear-waves/linear-waves-amr.inp
+++ b/test/test_files/linear-waves/linear-waves-amr.inp
@@ -37,8 +37,9 @@ OceanWaves.Wave1.wave_height=0.1
 OceanWaves.Wave1.wave_length=1.0
 OceanWaves.Wave1.water_depth=1.015625
 OceanWaves.Wave1.zero_sea_level = 0.015625
-OceanWaves.Wave1.relax_zone_gen_length=1.5
-OceanWaves.Wave1.numerical_beach_length=1.5
+OceanWaves.Wave1.relax_zone_gen_length=1.0
+OceanWaves.Wave1.numerical_beach_length=1.0
+OceanWaves.Wave1.numerical_beach_length_factor=2.0
 MultiPhase.density_fluid1=1000.
 MultiPhase.density_fluid2=1.
 ICNS.source_terms = GravityForcing
@@ -47,20 +48,20 @@ incflo.initial_iterations = 0
 incflo.do_initial_proj = false
 
 incflo.diffusion_type = 0
-nodal_proj.max_coarsening_level = 2
+nodal_proj.max_coarsening_level = 1
 mac_proj.max_coarsening_level = 6
 
 MultiPhase.verbose=0
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #
 #.......................................#
-amr.n_cell              = 256 32 64    # Grid cells at coarsest AMRlevel
+amr.n_cell              = 64 16 32    # Grid cells at coarsest AMRlevel
 amr.max_level = 0
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              GEOMETRY                 #
 #.......................................#
-geometry.prob_lo        =     0.0  -0.5  -1.0   # Lo corner coordinates
-geometry.prob_hi        =     8.   0.5   1.0  # Hi corner coordinates
+geometry.prob_lo        =     0.0  -0.4  -1.0   # Lo corner coordinates
+geometry.prob_hi        =     3.2   0.4   0.6  # Hi corner coordinates
 geometry.is_periodic    =     0     1     0   # Periodicity x y z (0/1)
 
 xlo.type =     "slip_wall"

--- a/test/test_files/linear-waves/linear-waves-nalu.yaml
+++ b/test/test_files/linear-waves/linear-waves-nalu.yaml
@@ -28,7 +28,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: "generated:64x16x50|bbox:3.0,-0.25,-0.5,5.0,0.25,0.5|sideset:xXyYzZ|show"
+    mesh: "generated:24x16x32|bbox:1.5,-0.25,-0.5,2.0,0.25,0.5|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
     check_for_missing_bcs: yes

--- a/test/test_files/sloshing-tank/sloshing-tank-amr.inp
+++ b/test/test_files/sloshing-tank/sloshing-tank-amr.inp
@@ -2,7 +2,7 @@ time.stop_time               =   20     # Max (simulated) time to evolve
 time.max_step                =   -10    # Max number of time steps
 
 time.initial_dt       =   -0.05        # Use this constant dt if > 0
-time.fixed_dt         =   0.005
+time.fixed_dt         =   0.01
 time.cfl              =   0.95         # CFL factor
 time.plot_interval            =  10       # Steps between plot files
 incflo.do_initial_proj = 0
@@ -31,7 +31,7 @@ SloshingTank.water_level=0.0
 ICNS.source_terms = GravityForcing
 
 # Target resolution at interface is dx = dy = 0.3125, dz = 0.125
-amr.n_cell              = 64 64 48   # Grid cells at coarsest AMRlevel
+amr.n_cell              = 32 32 24   # Grid cells at coarsest AMRlevel
 amr.max_level = 0
 
 geometry.prob_lo        =   -2.  -2.   -1.5   # Lo corner coordinates

--- a/test/test_files/sloshing-tank/sloshing-tank-nalu.yaml
+++ b/test/test_files/sloshing-tank/sloshing-tank-nalu.yaml
@@ -28,7 +28,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: "generated:32x32x32|bbox:-1.0,-1.0,-1.0,1.,1.,1.0|sideset:xXyYzZ|show"
+    mesh: "generated:16x16x16|bbox:-1.0,-1.0,-1.0,1.,1.,1.0|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
     check_for_missing_bcs: yes
@@ -132,7 +132,7 @@ Time_Integrators:
       name: ti_1
       start_time: 0.0
       termination_time: 2.0
-      time_step: 0.005
+      time_step: 0.01
       time_stepping_type: fixed
       time_step_count: 0
       second_order_accuracy: yes

--- a/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-amr.inp
+++ b/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-amr.inp
@@ -2,7 +2,7 @@ time.stop_time               =   200     # Max (simulated) time to evolve
 time.max_step                =   -10    # Max number of time steps
 
 time.initial_dt       =   -0.05        # Use this constant dt if > 0
-time.fixed_dt         =   0.01
+time.fixed_dt         =   0.02
 time.cfl              =   0.95         # CFL factor
 time.plot_interval            =  10       # Steps between plot files
 incflo.do_initial_proj = 0
@@ -45,17 +45,18 @@ nodal_proj.max_coarsening_level = 1
 nodal_proj.num_pre_smooth = 8
 nodal_proj.num_post_smooth = 8
 
-amr.n_cell              = 64 32 48
-amr.max_level = 1
+amr.n_cell              = 16 8 16
+amr.max_level = 2
 
-geometry.prob_lo        =   -6  -5  -10.0   # Lo corner coordinates
-geometry.prob_hi        =    14  5   5   # Hi corner coordinates
+geometry.prob_lo        =   -6  -3  -10.0   # Lo corner coordinates
+geometry.prob_hi        =    6   3    2   # Hi corner coordinates
 geometry.is_periodic    =    0   0    0   # Periodicity x y z (0/1)
 
 tagging.labels = refine0
 tagging.refine0.type = GeometryRefinement
 tagging.refine0.shapes = c0 b0
-tagging.refine0.level  = 0
+tagging.refine0.min_level  = 0
+tagging.refine0.max_level  = 1
 
 tagging.refine0.c0.type = cylinder
 tagging.refine0.c0.start = 0.0 0.0 -2.0
@@ -63,9 +64,9 @@ tagging.refine0.c0.end = 0.0 0.0 1.5
 tagging.refine0.c0.outer_radius = 0.5
 
 tagging.refine0.b0.type = box                 
-tagging.refine0.b0.origin = -10.0 -5.5 -0.5
+tagging.refine0.b0.origin = -10.0 -3.0 -0.5
 tagging.refine0.b0.xaxis = 30.0 0.0 0.0
-tagging.refine0.b0.yaxis = 0.0 11.0 0.0
+tagging.refine0.b0.yaxis = 0.0 6.0 0.0
 tagging.refine0.b0.zaxis = 0.0 0.0 1.0
 
 xlo.type =   "wave_generation"

--- a/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-nalu.yaml
+++ b/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-nalu.yaml
@@ -134,7 +134,7 @@ realms:
 
     output:
       output_data_base_name: out/stokesWavesCylinder.e
-      output_frequency: 20
+      output_frequency: 10
       output_node_set: yes
       output_variables:
        - density
@@ -154,7 +154,7 @@ Time_Integrators:
       name: ti_1
       start_time: 0.0
       termination_time: 200.0
-      time_step: 0.01
+      time_step: 0.02
       time_stepping_type: fixed
       time_step_count: 0
       second_order_accuracy: yes

--- a/test/test_files/zalesak/zalesak-nalu.yaml
+++ b/test/test_files/zalesak/zalesak-nalu.yaml
@@ -18,7 +18,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: "generated:32x32x32|bbox:0.25,0.,0.,0.75,0.5,0.5|sideset:xXyYzZ|show"
+    mesh: "generated:32x32x32|bbox:0.0,0.15,0.0,0.5,0.65,0.5|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
     check_for_missing_bcs: yes


### PR DESCRIPTION
Reduced grid cell counts, increased time steps where relevant.

Tweaked some cases to ensure there is overset interaction during the 10 steps of the reg test. 

Overall, these makes the cases much better as reg tests but would need to be modified to serve as good verification or validation cases.

Closes #97 