### PR TITLE
update regression tests to use pressure initialization

### DIFF
--- a/test/test_files/flat-surface/flat-surface-nalu.yaml
+++ b/test/test_files/flat-surface/flat-surface-nalu.yaml
@@ -59,13 +59,14 @@ realms:
         target_name: block_1
         user_function_name:
           volume_of_fluid: sloshing_tank
+          pressure: sloshing_tank
         user_function_parameters:
           volume_of_fluid: [-0.1015625, 0.0, 0.25, 0.03]
+          pressure: [-0.1015625, 0.0, 0.25, 0.03, 0.5]
 
       - constant: ic_1
         target_name: block_1
         value:
-          pressure: 0.0
           velocity: [0.0, 0.0, 0.0]
 
     material_properties:

--- a/test/test_files/linear-waves/linear-waves-amr.inp
+++ b/test/test_files/linear-waves/linear-waves-amr.inp
@@ -42,6 +42,7 @@ OceanWaves.Wave1.numerical_beach_length=1.0
 OceanWaves.Wave1.numerical_beach_length_factor=2.0
 MultiPhase.density_fluid1=1000.
 MultiPhase.density_fluid2=1.
+MultiPhase.initialize_pressure = true
 ICNS.source_terms = GravityForcing
 
 incflo.initial_iterations = 0
@@ -70,17 +71,7 @@ geometry.is_periodic    =     0     1     0   # Periodicity x y z (0/1)
 
 xlo.type =     "slip_wall"
 xhi.type =     "slip_wall"
-xlo.vof_type = "zero_gradient"
-xhi.vof_type = "zero_gradient"
-xlo.density_type = "zero_gradient"
-xhi.density_type = "zero_gradient"
-
 zlo.type =     "slip_wall"
 zhi.type =     "slip_wall"
-zlo.vof_type = "zero_gradient"
-zhi.vof_type = "zero_gradient"
-zlo.density_type = "zero_gradient"
-zhi.density_type = "zero_gradient"
 
 incflo.verbose=0
-

--- a/test/test_files/linear-waves/linear-waves-amr.inp
+++ b/test/test_files/linear-waves/linear-waves-amr.inp
@@ -75,3 +75,5 @@ zlo.type =     "slip_wall"
 zhi.type =     "slip_wall"
 
 incflo.verbose=0
+
+amrex.the_arena_init_size = 0

--- a/test/test_files/linear-waves/linear-waves-nalu.yaml
+++ b/test/test_files/linear-waves/linear-waves-nalu.yaml
@@ -59,13 +59,14 @@ realms:
         target_name: block_1
         user_function_name:
           volume_of_fluid: sloshing_tank
+          pressure: sloshing_tank
         user_function_parameters:
           volume_of_fluid: [0.015625, 0.0, 0.25, 0.06]
+          pressure: [0.015625, 0.0, 0.25, 0.06, 0.6]
 
       - constant: ic_1
         target_name: block_1
         value:
-          pressure: 0.0
           velocity: [0.0, 0.0, 0.0]
 
     material_properties:

--- a/test/test_files/sloshing-tank/sloshing-tank-amr.inp
+++ b/test/test_files/sloshing-tank/sloshing-tank-amr.inp
@@ -5,6 +5,7 @@ time.initial_dt       =   -0.05        # Use this constant dt if > 0
 time.fixed_dt         =   0.01
 time.cfl              =   0.95         # CFL factor
 time.plot_interval            =  10       # Steps between plot files
+time.use_force_cfl= false
 incflo.do_initial_proj = 0
 incflo.initial_iterations = 0
 
@@ -20,8 +21,11 @@ turbulence.model = Laminar
 
 nodal_proj.mg_rtol = 1.0e-12
 nodal_proj.mg_atol = 1.0e-12
+nodal_proj.bottom_atol = 1e-14
+nodal_proj.max_coarsening_level = 0
 mac_proj.mg_rtol = 1.0e-12
 mac_proj.mg_atol = 1.0e-12
+mac_proj.bottom_atol = 1e-14
 mac_proj.max_coarsening_level = 2
 
 incflo.physics = MultiPhase SloshingTank
@@ -31,6 +35,7 @@ MultiPhase.water_level=0.0
 SloshingTank.amplitude=0.7
 SloshingTank.peak_enhance=1.5
 SloshingTank.water_level=0.0
+SloshingTank.initialize_pressure = true
 ICNS.source_terms = GravityForcing
 
 # Target resolution at interface is dx = dy = 0.3125, dz = 0.125

--- a/test/test_files/sloshing-tank/sloshing-tank-nalu.yaml
+++ b/test/test_files/sloshing-tank/sloshing-tank-nalu.yaml
@@ -59,13 +59,14 @@ realms:
         target_name: block_1
         user_function_name:
           volume_of_fluid: sloshing_tank
+          pressure: sloshing_tank
         user_function_parameters:
           volume_of_fluid: [0., 0.7, 1.5, 0.06]
+          pressure: [0., 0.7, 1.5, 0.06, 1.5]
 
       - constant: ic_1
         target_name: block_1
         value:
-          pressure: 0.0
           velocity: [0.0, 0.0, 0.0] 
 
     material_properties:

--- a/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-amr.inp
+++ b/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-amr.inp
@@ -33,6 +33,7 @@ OceanWaves.Wave1.numerical_beach_length_factor=2.0
 OceanWaves.Wave1.zero_sea_level=0.0
 MultiPhase.density_fluid1=1000.
 MultiPhase.density_fluid2=1.
+MultiPhase.initialize_pressure=true
 ICNS.source_terms = GravityForcing
 
 ICNS.use_perturb_pressure = true

--- a/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-nalu.yaml
+++ b/test/test_files/stokes-waves-cylinder/stokes-waves-cylinder-nalu.yaml
@@ -59,14 +59,15 @@ realms:
         target_name: oset
         user_function_name:
           volume_of_fluid: sloshing_tank
+          pressure: sloshing_tank
         user_function_parameters:
           volume_of_fluid: [0.0, 0.0, 0.25, 0.1]
+          pressure: [0.0, 0.0, 0.25, 0.1, 2.]
 
       - constant: ic_1
         target_name: oset
         value:
           velocity: [0.0, 0.0, 0.0]
-          pressure: 0.0
 
     material_properties:
       target_name: oset


### PR DESCRIPTION
relies on a PR from Nalu-Wind (https://github.com/Exawind/nalu-wind/pull/1379) to run, relies on a PR from AMR-Wind (https://github.com/Exawind/amr-wind/pull/1687) to be correct.